### PR TITLE
increase noise_width max to 5000 Hz

### DIFF
--- a/source/common/vutuProcessor.cpp
+++ b/source/common/vutuProcessor.cpp
@@ -89,7 +89,7 @@ void readParameterDescriptions(ParameterDescriptionList& params)
   
   params.push_back( ml::make_unique< ParameterDescription >(WithValues{
     { "name", "noise_width" },
-    { "range", {10, 500} },
+    { "range", {10, 5000} },
     { "plaindefault", 50 },
     { "log", false },
     { "units", "Hz" }


### PR DESCRIPTION
Wider noise width results in better models for some sounds, closes madronalabs/vutu#3